### PR TITLE
Trivyで秘匿情報を検知する

### DIFF
--- a/.github/workflows/secrets-scan.yaml
+++ b/.github/workflows/secrets-scan.yaml
@@ -1,0 +1,58 @@
+name: Secrets Scan with Trivy
+
+on:
+  pull_request:
+
+jobs:
+  filter:
+    runs-on: ubuntu-latest
+    outputs:
+      workdirs: ${{ steps.dirs.outputs.workdirs }}
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v4.1.1
+      with:
+        ref: ${{ github.head_ref }}
+
+    - name: Fetch PR base ref
+      run: |
+        git fetch --depth=1 origin ${{ github.base_ref }}:${{ github.base_ref }}
+
+    # 変更の入ったディレクトリのみ取得する
+    - name: Get changed directories
+      id: dirs
+      run: |
+        workdirs=$(git diff --name-only ${{ github.base_ref }} ${{ github.head_ref }} | xargs -I {} dirname {} | jq -R -s -c 'split("\n")[:-1]')
+        echo "workdirs=$workdirs" >> $GITHUB_OUTPUT
+
+
+  scan:
+    needs: filter
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        workdir: ${{ fromJSON(needs.filter.outputs.workdirs) }}
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v4.1.1
+      with:
+        ref: ${{ github.head_ref }}
+
+    - name: Run Aqua Security Trivy
+      uses: aquasecurity/trivy-action@0.15.0
+      with:
+        scan-type: fs
+        scan-ref: ${{ matrix.workdir }}
+        severity: UNKNOWN,LOW,MEDIUM,HIGH,CRITICAL # default
+        scanners: secret
+        output: trivy.txt
+        exit-code: 1
+
+    - name: Post PR comments
+      if: failure()
+      env:
+        GITHUB_TOKEN: ${{ github.token }}
+        URL: ${{ github.event.pull_request.html_url }}
+      run:
+        sed -i -e '1i ```' -e '$a ```' trivy.txt
+        gh pr comment -F ./trivy.txt "${URL}" 


### PR DESCRIPTION
## 概要
* https://github.com/globis-org/core-infra/issues/2425
* 秘匿情報が含まれていた場合、検知してPRにコメントをする GitHub Actions Workflow の追加です。

## レビューポイント
* とりあえず実装だけ。
* README や renovate 周り設定は後ほど。

## 関連URL
* [aquasecurity/trivy-action](https://github.com/aquasecurity/trivy-action)
* [GitHub docs マージ前にワークフローに渡すことを必須にする](https://docs.github.com/ja/enterprise-cloud@latest/repositories/configuring-branches-and-merges-in-your-repository/managing-rulesets/available-rules-for-rulesets#require-workflows-to-pass-before-merging)