### PR TITLE
mod: コマンドを複数記述する場合は|が必要だったため修正する

### DIFF
--- a/.github/workflows/secrets-scan.yaml
+++ b/.github/workflows/secrets-scan.yaml
@@ -53,6 +53,6 @@ jobs:
       env:
         GITHUB_TOKEN: ${{ github.token }}
         URL: ${{ github.event.pull_request.html_url }}
-      run:
+      run: |
         sed -i -e '1i ```' -e '$a ```' trivy.txt
         gh pr comment -F ./trivy.txt "${URL}" 


### PR DESCRIPTION
## 概要
* https://github.com/globis-org/core-infra/issues/2425
* `|` の追加を忘れていて、一つのコマンドとして認識とされエラーが発生していたので修正します。

```
Run sed -i -e '1i ```' -e '$a ```' trivy.txt gh pr comment -F ./trivy.txt "${URL}"
  sed -i -e '1i ```' -e '$a ```' trivy.txt gh pr comment -F ./trivy.txt "${URL}"
  shell: /usr/bin/bash -e {0}
sed: invalid option -- 'F'
Usage: sed [OPTION]... {script-only-if-no-other-script} [input-file]...
```