### PR TITLE
scan結果コメントにNotion docsのリンクを貼る

### DIFF
--- a/.github/workflows/secrets-scan.yaml
+++ b/.github/workflows/secrets-scan.yaml
@@ -54,5 +54,5 @@ jobs:
         GITHUB_TOKEN: ${{ github.token }}
         URL: ${{ github.event.pull_request.html_url }}
       run: |
-        sed -i -e '1i ```' -e '$a ```' trivy.txt
+        sed -i -e '1i ```' -e '$a ```\nこのactionについては [Notion](https://www.notion.so/globisorg/GitHub-dcb884f8df2646df8d8e686bd6290d46) を参照。' trivy.txt
         gh pr comment -F ./trivy.txt "${URL}" 


### PR DESCRIPTION
scan結果が出たときに「これはなんだ？」とならないよう、
Notionで作成したドキュメントへのリンクを挿入します。