### PR TITLE
mod: スキャン対象のディレクトリが存在するかどうかの条件分岐を追加

### DIFF
--- a/.github/workflows/secrets-scan.yaml
+++ b/.github/workflows/secrets-scan.yaml
@@ -38,6 +38,15 @@ jobs:
       with:
         ref: ${{ github.head_ref }}
 
+    - name: Check if workdir exists
+      id: check
+      run: |
+        if [ -d "${{ matrix.workdir }}" ]; then
+          echo "exists=true" >> $GITHUB_OUTPUT
+        else
+          echo "exists=false" >> $GITHUB_OUTPUT
+        fi
+
     - name: Run Aqua Security Trivy
       uses: aquasecurity/trivy-action@0.15.0
       with:
@@ -47,6 +56,7 @@ jobs:
         scanners: secret
         output: trivy.txt
         exit-code: 1
+      if: steps.check.outputs.exists == 'true'
 
     - name: Post PR comments
       if: failure()


### PR DESCRIPTION
## 修正内容
* ディレクトリごと削除するPRを作成した場合、エラーが発生してしまうので修正します。
  * `git diff` で検査対象のPATHを指定している。
  * そのためディレクトリ毎削除した場合でも、検査対象のPATHとなるがPR BranchにはそのPATHが存在しない状況となっているため、スキャンで失敗するというもの。
* https://github.com/globis-org/unlimited-front/actions/runs/7285531351/job/19852618893

## 動作確認①
`github-action-test` という repo を作成してそちらで検証しました。
* https://github.com/globis-org/github-action-test/pull/15
この repo に 本PR の workflow と同一のものを配置してテストしてます。

1. `github-action-test` repo で `dir/dir2/hoge.txt` という階層にファイルを用意
2. `dir/dir2` というディレクトリを削除するPRを作成 skipされることを確認する

![image](https://github.com/globis-org/org-secrets-scan/assets/35423021/f72f86cf-766e-48de-84c5-f107244b7933)

## 動作確認②
1. 動作確認①に加えて、dummyのtokenが記載された `dummy.txt` を修正する。
2. `dummy.txt` の内容が検知されることを確認する。

![image](https://github.com/globis-org/org-secrets-scan/assets/35423021/dc66fde6-faa6-41f4-947a-71b0b01c4882)
