### PR TITLE
renovateでtrivy-actionのバージョンアップPRを作成する

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,0 +1,11 @@
+{
+    "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+    "extends": [
+      "github>globis-org/renovate-config:sre"
+    ],
+    "prConcurrentLimit": 10,
+    "prHourlyLimit": 0,
+    "enabledManagers": [
+      "github-actions"
+    ]
+}


### PR DESCRIPTION
## 概要
renovateでtrivy-actionのバージョンアップPRを作成するために `renovate.json` を追加します。

別途作成する必要もないかと思い、SREが用意している config を継承しています。