### PR TITLE
bugfix: ディレクトリのスキャンが同一PATHで複数回実行されてしまう

### DIFF
--- a/.github/workflows/secrets-scan.yaml
+++ b/.github/workflows/secrets-scan.yaml
@@ -22,7 +22,7 @@ jobs:
     - name: Get changed directories
       id: dirs
       run: |
-        workdirs=$(git diff --name-only ${{ github.base_ref }} ${{ github.head_ref }} | xargs -I {} dirname {} | jq -R -s -c 'split("\n")[:-1]')
+        workdirs=$(git diff --name-only ${{ github.base_ref }} ${{ github.head_ref }} | xargs -I {} dirname {} | sort | uniq | jq -R -s -c 'split("\n")[:-1]')
         echo "workdirs=$workdirs" >> $GITHUB_OUTPUT
 
 


### PR DESCRIPTION
## 概要
shellでスキャン対象PATHを抽出する過程で重複削除処理が入っておらず、後続の `matrix` の処理で同一PATHに複数回スキャンがかかっていたのを修正しました。

## 動作確認

before (dir が重複してしまっている。)
```
> git diff --name-only main uniq/test | xargs -I {} dirname {} | jq -R -s -c 'split("\n")[:-1]'              
[".","dir","dir"]
```

after
```
> git diff --name-only main uniq/test | xargs -I {} dirname {} | sort | uniq | jq -R -s -c 'split("\n")[:-1]'                               
[".","dir"]
```