### PR TITLE
feat: set permissions for workflow

### DIFF
--- a/.github/workflows/secrets-scan.yaml
+++ b/.github/workflows/secrets-scan.yaml
@@ -3,6 +3,10 @@ name: Secrets Scan with Trivy
 on:
   pull_request:
 
+permissions:
+  contents: read
+  pull-requests: write
+
 jobs:
   scan:
     runs-on: ubuntu-latest


### PR DESCRIPTION
* https://github.com/globis-org/core-infra/issues/2536

* Repository 単位の workflow(default) permission が `Read repository contents and packages permissions` だと pull request comment ができずにエラーが発生してしまう。
* default permission を利用せず、 `permissions` で明示的に権限を付与します。